### PR TITLE
Add .gitignore file ignoring xcuserdata folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata


### PR DESCRIPTION
What changed
---
Added .gitignore that ignores xcuserdata folder, as that folder is meant to be user-specific and shouldn't matter. This fixes this issue:
![screen shot 2017-01-20 at 12 37 15 pm](https://cloud.githubusercontent.com/assets/7478261/22164773/6efc98ea-df0d-11e6-8d72-73f4937616e9.png)

Will point quizlet-ios master to this commit once this PR has been merged into master of this repo

QA
---
N/A